### PR TITLE
Paywall Feature for Premium Articles

### DIFF
--- a/examples/blog-starter-typescript/_posts/dynamic-routing.md
+++ b/examples/blog-starter-typescript/_posts/dynamic-routing.md
@@ -2,6 +2,7 @@
 title: 'Dynamic Routing and Static Generation'
 excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus.'
 coverImage: '/assets/blog/dynamic-routing/cover.jpg'
+isPremium: true
 date: '2020-03-16T05:35:07.322Z'
 author:
   name: JJ Kasper

--- a/examples/blog-starter-typescript/_posts/hello-world.md
+++ b/examples/blog-starter-typescript/_posts/hello-world.md
@@ -2,6 +2,7 @@
 title: 'Learn How to Pre-render Pages Using Static Generation with Next.js'
 excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus.'
 coverImage: '/assets/blog/hello-world/cover.jpg'
+isPremium: false
 date: '2020-03-16T05:35:07.322Z'
 author:
   name: Tim Neutkens

--- a/examples/blog-starter-typescript/_posts/preview.md
+++ b/examples/blog-starter-typescript/_posts/preview.md
@@ -2,6 +2,7 @@
 title: 'Preview Mode for Static Generation'
 excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus.'
 coverImage: '/assets/blog/preview/cover.jpg'
+isPremium: false
 date: '2020-03-16T05:35:07.322Z'
 author:
   name: Joe Haddad

--- a/examples/blog-starter-typescript/components/hero-post.tsx
+++ b/examples/blog-starter-typescript/components/hero-post.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  isPremium: boolean
 }
 
 const HeroPost = ({
@@ -20,11 +21,13 @@ const HeroPost = ({
   excerpt,
   author,
   slug,
+  isPremium,
 }: Props) => {
   return (
     <section>
       <div className="mb-8 md:mb-16">
         <CoverImage title={title} src={coverImage} slug={slug} />
+        {isPremium && <span>Premium</span>}
       </div>
       <div className="md:grid md:grid-cols-2 md:gap-x-16 lg:gap-x-8 mb-20 md:mb-28">
         <div>

--- a/examples/blog-starter-typescript/components/more-stories.tsx
+++ b/examples/blog-starter-typescript/components/more-stories.tsx
@@ -21,6 +21,7 @@ const MoreStories = ({ posts }: Props) => {
             author={post.author}
             slug={post.slug}
             excerpt={post.excerpt}
+            isPremium={post.isPremium}
           />
         ))}
       </div>

--- a/examples/blog-starter-typescript/components/post-preview.tsx
+++ b/examples/blog-starter-typescript/components/post-preview.tsx
@@ -11,6 +11,7 @@ type Props = {
   excerpt: string
   author: Author
   slug: string
+  isPremium: boolean
 }
 
 const PostPreview = ({
@@ -20,11 +21,13 @@ const PostPreview = ({
   excerpt,
   author,
   slug,
+  isPremium,
 }: Props) => {
   return (
     <div>
       <div className="mb-5">
         <CoverImage slug={slug} title={title} src={coverImage} />
+        {isPremium && <span>Premium</span>}
       </div>
       <h3 className="text-3xl mb-3 leading-snug">
         <Link as={`/posts/${slug}`} href="/posts/[slug]">

--- a/examples/blog-starter-typescript/package.json
+++ b/examples/blog-starter-typescript/package.json
@@ -7,12 +7,14 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@types/reactjs-localstorage": "1.0.0",
     "classnames": "2.3.1",
     "date-fns": "2.21.3",
     "gray-matter": "4.0.3",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "reactjs-localstorage": "^1.0.1",
     "remark": "13.0.0",
     "remark-html": "13.0.1",
     "typescript": "^4.2.4"

--- a/examples/blog-starter-typescript/pages/index.tsx
+++ b/examples/blog-starter-typescript/pages/index.tsx
@@ -31,6 +31,7 @@ const Index = ({ allPosts }: Props) => {
               author={heroPost.author}
               slug={heroPost.slug}
               excerpt={heroPost.excerpt}
+              isPremium={heroPost.isPremium}
             />
           )}
           {morePosts.length > 0 && <MoreStories posts={morePosts} />}
@@ -50,6 +51,7 @@ export const getStaticProps = async () => {
     'author',
     'coverImage',
     'excerpt',
+    'isPremium',
   ])
 
   return {

--- a/examples/blog-starter-typescript/pages/posts/[slug].tsx
+++ b/examples/blog-starter-typescript/pages/posts/[slug].tsx
@@ -11,6 +11,8 @@ import Head from 'next/head'
 import { CMS_NAME } from '../../lib/constants'
 import markdownToHtml from '../../lib/markdownToHtml'
 import PostType from '../../types/post'
+import { useCallback, useEffect, useState } from 'react'
+import { reactLocalStorage } from 'reactjs-localstorage'
 
 type Props = {
   post: PostType
@@ -20,6 +22,58 @@ type Props = {
 
 const Post = ({ post, morePosts, preview }: Props) => {
   const router = useRouter()
+
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  useEffect(() => {
+    const isLoggedIn = reactLocalStorage.get('isLoggedIn', false)
+    setIsLoggedIn(isLoggedIn)
+  }, [])
+
+  const onUsernameChange = useCallback((e) => {
+    setUsername(e.target.value)
+  }, [])
+
+  const onPasswordChange = useCallback((e) => {
+    setPassword(e.target.value)
+  }, [])
+
+  const handleLogin = useCallback(() => {
+    if (username === 'complete' && password === 'complete') {
+      reactLocalStorage.set('isLoggedIn', true)
+      setIsLoggedIn(true)
+    } else {
+      alert('You have entered wrong username or password')
+    }
+  }, [username, password])
+
+  const renderLoginModal = post.isPremium ? !isLoggedIn : false
+
+  if (renderLoginModal) {
+    return (
+      <div>
+        <span>Please log in to see article about {post.title}</span>
+        <div style={{ marginTop: 10 }}>
+          <input
+            type="text"
+            value={username}
+            onChange={onUsernameChange}
+            style={{ borderWidth: 1 }}
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={onPasswordChange}
+            style={{ borderWidth: 1 }}
+          />
+          <button onClick={handleLogin}>Log In</button>
+        </div>
+      </div>
+    )
+  }
+
   if (!router.isFallback && !post?.slug) {
     return <ErrorPage statusCode={404} />
   }
@@ -70,6 +124,7 @@ export async function getStaticProps({ params }: Params) {
     'content',
     'ogImage',
     'coverImage',
+    'isPremium',
   ])
   const content = await markdownToHtml(post.content || '')
 

--- a/examples/blog-starter-typescript/types/post.ts
+++ b/examples/blog-starter-typescript/types/post.ts
@@ -11,6 +11,7 @@ type PostType = {
     url: string
   }
   content: string
+  isPremium: boolean
 }
 
 export default PostType


### PR DESCRIPTION

## Feature

- All Posts to show in home page whether it's premium content or not.
- Indication to show if it's premium post or not (by showing star at the top-right corner of image preview of blog post
- When a user clicks on or directly navigates to a premium article via link, they're prompted to log in.

## Internal Changes
- added package `reactjs-localstorage` & `@types/reactjs-localstorage` for storing key value pair in local storage
- added: `isPremium` key to post's markdown metadata

## Demo
[ we can include the demo video here to show case the changes and new feature we have implemented in this PR. ]